### PR TITLE
-fix: c++ version check for register removal

### DIFF
--- a/DevIL/DevIL/src-IL/src/il_manip.cpp
+++ b/DevIL/DevIL/src-IL/src/il_manip.cpp
@@ -36,11 +36,15 @@ ILushort ILAPIENTRY ilFloatToHalf(ILuint i) {
 	// Adjust e, accounting for the different exponent bias
 	// of float and half (127 versus 15).
 	//
-
+#if __cplusplus >= 201703L //fixes clang compilation, specifically version 17 (gcc doesn't seem to care about it)
+	int s =  (i >> 16) & 0x00008000;
+	int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+	int m =   i        & 0x007fffff;
+#else
 	register int s =  (i >> 16) & 0x00008000;
 	register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
 	register int m =   i        & 0x007fffff;
-
+#endif
 	//
 	// Now reassemble s, e and m into a half:
 	//


### PR DESCRIPTION
This fixes clang compilation, specifically version 17, which I assume it automatically compiles with -std=c++17